### PR TITLE
Add pytest to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google-cloud-spanner
+pytest


### PR DESCRIPTION
For some reason, it's not available for the integration test anymore.
Presumably the CI Docker image stayed the same, so maybe google-cloud-spanner
pulled it in before?